### PR TITLE
【Aランクレベルアップメニュー】マップの判定・横

### DIFF
--- a/src/a_rank_level_up_problems/mod.rs
+++ b/src/a_rank_level_up_problems/mod.rs
@@ -1,2 +1,3 @@
 pub mod snake_map_step1;
 pub mod snake_map_step2;
+pub mod snake_map_step3;

--- a/src/a_rank_level_up_problems/snake_map_step3.rs
+++ b/src/a_rank_level_up_problems/snake_map_step3.rs
@@ -31,12 +31,12 @@ impl SnakeMapStep3Resolver {
         }
 
         if x == 0 {
-            // 先頭なら左隣だけで判定
+            // 先頭なら右隣だけで判定
             return self.is_target_char(chars[x + 1]);
         }
 
         if x == chars_len - 1 {
-            // 最後なら右隣だけで判定
+            // 最後なら左隣だけで判定
             return self.is_target_char(chars[x - 1]);
         }
 

--- a/src/a_rank_level_up_problems/snake_map_step3.rs
+++ b/src/a_rank_level_up_problems/snake_map_step3.rs
@@ -1,0 +1,158 @@
+use crate::utils;
+
+pub fn main() {
+    utils::resolve(SnakeMapStep3Resolver {})
+}
+
+#[derive(Debug, PartialEq)]
+struct SnakeMapStep3Input {
+    map: Vec<String>,
+}
+
+struct SnakeMapStep3Resolver;
+
+impl SnakeMapStep3Resolver {
+    fn find_target_positions(&self, y_pos: usize, line: &String) -> Vec<(usize, usize)> {
+        let mut positions = Vec::new();
+
+        let chars: Vec<char> = line.chars().collect();
+        for x in 0..chars.len() {
+            if self.is_target_position_x(&chars, x) {
+                positions.push((x, y_pos));
+            }
+        }
+        return positions;
+    }
+
+    fn is_target_position_x(&self, chars: &Vec<char>, x: usize) -> bool {
+        let chars_len = chars.len();
+        if chars_len < 2 {
+            return false;
+        }
+
+        if x == 0 {
+            // 先頭なら左隣だけで判定
+            return self.is_target_char(chars[x + 1]);
+        }
+
+        if x == chars_len - 1 {
+            // 最後なら右隣だけで判定
+            return self.is_target_char(chars[x - 1]);
+        }
+
+        return self.is_target_char(chars[x - 1]) && self.is_target_char(chars[x + 1]);
+    }
+
+    fn is_target_char(&self, char: char) -> bool {
+        char.eq(&'#')
+    }
+}
+
+impl utils::Resolver for SnakeMapStep3Resolver {
+    type Input = SnakeMapStep3Input;
+
+    fn read_input(&self) -> Self::Input {
+        let first_line: Vec<usize> = utils::InputReader::read_line_splitted_by_whitespace();
+        let map_heigh = first_line[0];
+        SnakeMapStep3Input {
+            map: utils::InputReader::read_lines(map_heigh),
+        }
+    }
+
+    fn create_output(&self, input: Self::Input) -> String {
+        input
+            .map
+            .iter()
+            .enumerate()
+            .flat_map(|(y_pos, line)| self.find_target_positions(y_pos, line))
+            .map(|(x, y)| format!("{} {}", y, x))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::utils::Resolver;
+
+    use super::*;
+
+    #[test]
+    fn test_create_output_1() {
+        let input = SnakeMapStep3Input {
+            map: vec![
+                String::from("..."),
+                String::from("..."),
+                String::from("..."),
+            ],
+        };
+        let resolver = SnakeMapStep3Resolver {};
+
+        let actual = resolver.create_output(input);
+
+        assert_eq!(actual, String::from(""));
+    }
+
+    #[test]
+    fn test_create_output_2() {
+        let input = SnakeMapStep3Input {
+            map: vec![String::from("#.#")],
+        };
+        let resolver = SnakeMapStep3Resolver {};
+
+        let actual = resolver.create_output(input);
+
+        assert_eq!(actual, String::from("0 1"));
+    }
+
+    #[test]
+    fn test_create_output_3() {
+        let input = SnakeMapStep3Input {
+            map: vec![String::from(".#.")],
+        };
+        let resolver = SnakeMapStep3Resolver {};
+
+        let actual = resolver.create_output(input);
+
+        assert_eq!(actual, String::from("0 0\n0 2"));
+    }
+
+    #[test]
+    fn test_create_output_4() {
+        let input = SnakeMapStep3Input {
+            map: vec![
+                String::from("#.#"),
+                String::from(".#."),
+                String::from("..."),
+            ],
+        };
+        let resolver = SnakeMapStep3Resolver {};
+
+        let actual = resolver.create_output(input);
+
+        assert_eq!(actual, String::from("0 1\n1 0\n1 2"));
+    }
+
+    #[test]
+    fn test_create_output_5() {
+        let input = SnakeMapStep3Input {
+            map: vec![
+                String::from("####"),
+                String::from("####"),
+                String::from("####"),
+                String::from("####"),
+            ],
+        };
+        let resolver = SnakeMapStep3Resolver {};
+
+        let actual = resolver.create_output(input);
+
+        assert_eq!(
+            actual,
+            String::from(
+                "0 0\n0 1\n0 2\n0 3\n1 0\n1 1\n1 2\n1 3\n2 0\n2 1\n2 2\n2 3\n3 0\n3 1\n3 2\n3 3"
+            )
+        );
+    }
+}


### PR DESCRIPTION
### 問題
https://paiza.jp/works/mondai/a_rank_level_up_problems/a_rank_snake_map_step3

### 提出コード

```
fn main() {
    utils::resolve(SnakeMapStep3Resolver {})
}

#[derive(Debug, PartialEq)]
struct SnakeMapStep3Input {
    map: Vec<String>,
}

struct SnakeMapStep3Resolver;

impl SnakeMapStep3Resolver {
    fn find_target_positions(&self, y_pos: usize, line: &String) -> Vec<(usize, usize)> {
        let mut positions = Vec::new();

        let chars: Vec<char> = line.chars().collect();
        for x in 0..chars.len() {
            if self.is_target_position_x(&chars, x) {
                positions.push((x, y_pos));
            }
        }
        return positions;
    }

    fn is_target_position_x(&self, chars: &Vec<char>, x: usize) -> bool {
        let chars_len = chars.len();
        if chars_len < 2 {
            return false;
        }

        if x == 0 {
            // 先頭なら右隣だけで判定
            return self.is_target_char(chars[x + 1]);
        }

        if x == chars_len - 1 {
            // 最後なら左隣だけで判定
            return self.is_target_char(chars[x - 1]);
        }

        return self.is_target_char(chars[x - 1]) && self.is_target_char(chars[x + 1]);
    }

    fn is_target_char(&self, char: char) -> bool {
        char.eq(&'#')
    }
}

impl utils::Resolver for SnakeMapStep3Resolver {
    type Input = SnakeMapStep3Input;

    fn read_input(&self) -> Self::Input {
        let first_line: Vec<usize> = utils::InputReader::read_line_splitted_by_whitespace();
        let map_heigh = first_line[0];
        SnakeMapStep3Input {
            map: utils::InputReader::read_lines(map_heigh),
        }
    }

    fn create_output(&self, input: Self::Input) -> String {
        input
            .map
            .iter()
            .enumerate()
            .flat_map(|(y_pos, line)| self.find_target_positions(y_pos, line))
            .map(|(x, y)| format!("{} {}", y, x))
            .collect::<Vec<_>>()
            .join("\n")
    }
}

mod utils {
    pub fn resolve<T: Resolver>(resolver: T) {
        let input = resolver.read_input();
        let output = resolver.create_output(input);
        println!("{}", output);
    }

    pub trait Resolver {
        type Input;
        fn read_input(&self) -> Self::Input;
        fn create_output(&self, input: Self::Input) -> String;
    }

    pub struct InputReader;

    impl InputReader {
        pub fn read_lines<T: std::str::FromStr>(times: usize) -> Vec<T> {
            (0..times).map(|_| InputReader::read_line()).collect()
        }

        pub fn read_lines_splitted_by_whitespace<T: std::str::FromStr>(times: usize) -> Vec<Vec<T>> {
            (0..times)
                .map(|_| InputReader::read_line_splitted_by_whitespace())
                .collect()
        }

        pub fn read_line_splitted_by_whitespace<T: std::str::FromStr>() -> Vec<T> {
            let line: String = InputReader::read_line();
            line.split_whitespace()
                .map(|c| c.parse().ok().unwrap())
                .collect()
        }

        pub fn read_line<T: std::str::FromStr>() -> T {
            let mut s = String::new();
            std::io::stdin().read_line(&mut s).unwrap();
            s.trim().parse().ok().unwrap()
        }
    }
}
```